### PR TITLE
Make it possible to specify languages in configuration phase

### DIFF
--- a/projects/ngx-cookie-consent/package.json
+++ b/projects/ngx-cookie-consent/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@localia/ngx-cookie-consent",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Angular module to display a cookie consent banner without other dependencies.",
     "author": "Giacomo Barbalinardo <me@giacomo.dev>",
     "license": "MIT",

--- a/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.spec.ts
+++ b/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import * as languages from '../languages';
 
 import { NgxCookieConsentConfigService } from './ngx-cookie-consent-config.service';
 
@@ -19,6 +20,7 @@ describe('NgxCookieConsentConfigService', () => {
         expect(service.imprintUrl).toEqual('#');
         expect(service.defaultLanguage).toEqual('en');
         expect(service.availableLanguages).toEqual(['en', 'de', 'it', 'pt']);
+        expect(service.languages).toEqual(languages);
         expect(service.showLanguageSwitcher).toEqual(true);
         expect(service.showBadgeOpener).toEqual(true);
         expect(service.openerPosition).toEqual('left-bottom');

--- a/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.ts
+++ b/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.ts
@@ -11,7 +11,7 @@ export class NgxCookieConsentConfigService {
     imprintUrl?: string | TranslatableString = '#';
     defaultLanguage?: string = 'en';
     availableLanguages?: string[] = ['en', 'de', 'it', 'pt'];
-    languages: { [key: string]: { [key: string]: string }} = languages;
+    languages?: { [key: string]: { [key: string]: string }} = languages;
     showLanguageSwitcher?: boolean = true;
     showBadgeOpener?: boolean = true;
     openerPosition?: 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' = 'left-bottom';

--- a/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.ts
+++ b/projects/ngx-cookie-consent/src/lib/config/ngx-cookie-consent-config.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CookieItem } from './cookie-item.interface';
 import { TranslatableString } from './translatable-string.interface';
+import * as languages from '../languages';
 
 @Injectable({
     providedIn: 'root'
@@ -10,6 +11,7 @@ export class NgxCookieConsentConfigService {
     imprintUrl?: string | TranslatableString = '#';
     defaultLanguage?: string = 'en';
     availableLanguages?: string[] = ['en', 'de', 'it', 'pt'];
+    languages: { [key: string]: { [key: string]: string }} = languages;
     showLanguageSwitcher?: boolean = true;
     showBadgeOpener?: boolean = true;
     openerPosition?: 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' = 'left-bottom';

--- a/projects/ngx-cookie-consent/src/lib/services/ngx-language/ngx-language.service.ts
+++ b/projects/ngx-cookie-consent/src/lib/services/ngx-language/ngx-language.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import * as languages from './../../languages';
 import { NgxCookieConsentConfigService } from '../../config/ngx-cookie-consent-config.service';
 
 @Injectable({
@@ -11,7 +10,7 @@ export class NgxLanguageService {
 
     constructor(private config: NgxCookieConsentConfigService) {
         this.translationKey = 'lang_' + this.config.defaultLanguage;
-        this.translations = languages;
+        this.translations = this.config.languages;
     }
 
 

--- a/projects/ngx-cookie-consent/src/public-api.ts
+++ b/projects/ngx-cookie-consent/src/public-api.ts
@@ -7,3 +7,4 @@ export * from './lib/services/ngx-cookie-manager/ngx-cookie-manager.service';
 export * from './lib/directives/if-consent/if-consent.directive';
 export * from './lib/ngx-cookie-consent.component';
 export * from './lib/ngx-cookie-consent.module';
+export * from './lib/languages';


### PR DESCRIPTION
Currently languages are hard coded and we cant edit the list of languages without having to rebuild.
With this change it would be possible to inject the language object at config phase.