### PR TITLE
fix(cookie): write consent cookie with SameSite=Lax so it persists in Firefox and Safari (possibly others)

### DIFF
--- a/projects/ngx-cookie-consent/src/lib/services/ngx-cookie/ngx-cookie.service.ts
+++ b/projects/ngx-cookie-consent/src/lib/services/ngx-cookie/ngx-cookie.service.ts
@@ -69,7 +69,7 @@ export class NgxCookieService {
       const dateExpires: Date = new Date( new Date().getTime() + expiringDays * 86400000);
       cookieString += 'expires=' + dateExpires.toUTCString() + ';';
       cookieString += 'path=' + path + ';';
-      cookieString += 'SameSite=None; Secure;';
+      cookieString += 'SameSite=Lax; Secure;';
 
       this.document.cookie = cookieString;
   }
@@ -83,7 +83,7 @@ export class NgxCookieService {
 
       cookieString += 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
       cookieString += 'path=' + path + ';';
-      cookieString += 'SameSite=None; Secure;';
+      cookieString += 'SameSite=Lax; Secure;';
 
       this.document.cookie = cookieString;
   }


### PR DESCRIPTION
`NgxCookieService.set() `and `delete()` write the consent cookie with `SameSite=None; Secure`. `SameSite=None` declares a cross-site cookie, which is wrong for a first-party consent cookie. On a deployed HTTPS site this is not reliably persisted in Firefox, so `shouldDisplayCookieConsent()` keeps returning true and the banner reappears on every NavigationEnd and cannot be dismissed. No console error is produced. Chrome is unaffected. Fixes #16 

Change: use SameSite=Lax, the correct attribute for a first-party cookie. Secure is retained.